### PR TITLE
Add presale page on mainnet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,8 @@ export default function App() {
   return (
     <div style={{background:"#11131a",minHeight:"100vh",color:"#0fffc7",display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center"}}>
       <nav style={{marginBottom:"32px"}}>
-        <Link to="/" style={{color:'#0fffc7',marginRight:'20px'}}>Home</Link>
-        <Link to="/wallet" style={{color:'#0fffc7'}}>Wallet</Link>
+        <Link to="/" style={{color:'#0fffc7',marginRight:'20px'}}>Wallet</Link>
+        <Link to="/presale" style={{color:'#0fffc7'}}>Pre-Sale</Link>
       </nav>
       <h2>RA Atum – Home Page</h2>
       <p>Welcome! Use the wallet button at bottom right to connect.</p>

--- a/src/PreSalePage.jsx
+++ b/src/PreSalePage.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import { useWeb3Modal } from "@web3modal/wagmi/react";
+import { useAccount, useWriteContract } from "wagmi";
+
+// Example presale contract placeholder
+const presaleAddress = "0x0000000000000000000000000000000000000000";
+const presaleABI = [
+  {
+    inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
+    name: "purchase",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+];
+
+export default function PreSalePage() {
+  const { open } = useWeb3Modal();
+  const { isConnected } = useAccount();
+  const [amount, setAmount] = useState(0);
+  const { writeContract, isPending } = useWriteContract();
+
+  const handleBuy = async () => {
+    try {
+      await writeContract({
+        address: presaleAddress,
+        abi: presaleABI,
+        functionName: "purchase",
+        args: [amount],
+        chainId: 56, // BNB mainnet
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div style={{
+      background: "#0e1018",
+      minHeight: "100vh",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "#ffffff",
+    }}>
+      <h2>Token Pre‑Sale</h2>
+      <button
+        style={{ marginBottom: 20, padding: "10px 20px" }}
+        onClick={open}
+      >
+        {isConnected ? "Connected" : "Connect Wallet"}
+      </button>
+      <div style={{ display: "flex", gap: 10 }}>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          style={{ padding: "8px", width: 140 }}
+        />
+        <button onClick={handleBuy} disabled={!isConnected || isPending}>
+          Buy Tokens
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import { mainnet, bsc } from 'wagmi/chains';
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from './App.jsx';
 import WalletPage from './WalletPage.jsx';
+import PreSalePage from './PreSalePage.jsx';
 
 const projectId = '12d853ddc01d124d1788bce412bd3020';
 
@@ -32,10 +33,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <WagmiProvider config={wagmiConfig}>
         <BrowserRouter>
           <Routes>
-  <Route path="/" element={<WalletPage />} />
-  {/* Optionally, keep your original App page on another route: */}
-  <Route path="/app" element={<App />} />
-</Routes>
+            <Route path="/" element={<WalletPage />} />
+            <Route path="/presale" element={<PreSalePage />} />
+            {/* Optionally, keep your original App page on another route: */}
+            <Route path="/app" element={<App />} />
+          </Routes>
 
         </BrowserRouter>
       </WagmiProvider>


### PR DESCRIPTION
## Summary
- create `PreSalePage` component with purchase form
- expose new `/presale` route
- update nav links

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ecbc377dc8320973d52150e539b82